### PR TITLE
downgrade pillow from 10.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ __keywords__ = [
 __requires__ = [
     'setuptools',
     'numpy',
-    'pillow>=3.4.0',
+    'pillow>=3.4.0,<10.0.0',
     'colorzero>=1.1',
 ]
 


### PR DESCRIPTION
Pillow 10.0.0 removes textsize from the library. Without changing the code this solves the problem for now.